### PR TITLE
Perplexity calculation

### DIFF
--- a/LanguageModel/NGram.cs
+++ b/LanguageModel/NGram.cs
@@ -1,4 +1,6 @@
-﻿namespace LanguageModel;
+﻿using System.Globalization;
+
+namespace LanguageModel;
 public class NGram
 {
     public readonly uint Size;
@@ -27,7 +29,7 @@ public class NGram
             foreach (var next in context.Value)
             {
                 string ngram = $"{context.Key} {next.Key}";
-                outputStreamWriter.WriteLine($"{next.Value} {ngram}");
+                outputStreamWriter.WriteLine($"{next.Value.ToString(CultureInfo.InvariantCulture)} {ngram}");
             }
         }
     }

--- a/LanguageModel/NGramLanguageModel.cs
+++ b/LanguageModel/NGramLanguageModel.cs
@@ -152,7 +152,7 @@ public class NGramLanguageModel
         List<string> tokens = sentence.Split(' ').ToList();
         tokens.Insert(0, "<s>");
         tokens.Add("</s>");
-        double perplexity = 1;
+        double sentenceProbability = 1;
         uint size = NGrams.Keys.Max();
 
         for (int index = 0; index < tokens.Count; index++)
@@ -189,11 +189,15 @@ public class NGramLanguageModel
             } while (currentSearchedSize > 0 && p == 0); // check all ngram sizes starting from longest until we checked all or got a value
 
             // multiply to result
-            perplexity *= p;
+            sentenceProbability *= p;
         }
 
-        double perplexityLog10 = Math.Log10(perplexity);
+        // calculate cross-entropy according to slides
+        double crossEntropy = (double)-1 / tokens.Count * Math.Log10(sentenceProbability);
 
-        return perplexityLog10;
+        // calculate perplexity
+        double perplexity = Math.Pow(2, crossEntropy);
+
+        return perplexity;
     }
 }

--- a/LanguageModel/NGramLanguageModel.cs
+++ b/LanguageModel/NGramLanguageModel.cs
@@ -149,11 +149,24 @@ public class NGramLanguageModel
         tokens.Insert(0, "<s>");
         tokens.Add("</s>");
         double perplexity = 1;
+        uint size = NGrams.Keys.Max();
 
         for (int index = 0; index < tokens.Count; index++)
         {
             // get probability of ngram
-            double p = 0.5;
+            double p = 0;
+            uint currentSearchedSize = size;
+            do
+            {
+                int contextStartIndex = (int)(index - currentSearchedSize);
+                string context = contextStartIndex > 0 ? String.Join(' ', tokens.Take(new Range(new Index(contextStartIndex), new Index(index - 1)))) : "";
+                string next = tokens[index];
+                if (NGrams[currentSearchedSize].NGrams.ContainsKey(context) && NGrams[currentSearchedSize].NGrams[context].ContainsKey(next))
+                {
+                    p = NGrams[currentSearchedSize].NGrams[context][next];
+                }
+                currentSearchedSize--;
+            } while (currentSearchedSize > 0 && p == 0); // check all ngram sizes starting from longest until we checked all or got a value
 
             // multiply
             perplexity *= p;

--- a/LanguageModel/NGramLanguageModel.cs
+++ b/LanguageModel/NGramLanguageModel.cs
@@ -41,4 +41,124 @@ public class NGramLanguageModel
     }
 
     public void GetArpaRepresentation(Stream outputStream) => GetArpaRepresentation(new StreamWriter(outputStream));
+
+    public static NGramLanguageModel LoadFrom(StreamReader inputStream)
+    {
+        // First line of header
+        string? currentLine = inputStream.ReadLine();
+        if (!"\\data\\".Equals(currentLine))
+        {
+            throw new InvalidDataException($"Invalid ARPA data: Expected \"\\data\\\", but got {currentLine}");
+        }
+
+        // Remaining part of header
+        var counts = new Dictionary<int, int>();
+        while((currentLine = inputStream.ReadLine()) != "")
+        {
+            if (currentLine is null)
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Expected \"ngram <x> = <y>\", but got NULL");
+            }
+            string[] splitted = currentLine.Split(' ');
+            if (splitted.Length != 4)
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Expected \"ngram <x> = <y>\", but got {currentLine}");
+            }
+            bool success = true;
+            success &= splitted[0].Equals("ngram");
+            success &= splitted[2].Equals("=");
+            success &= Int32.TryParse(splitted[1], out int ngramSize);
+            success &= Int32.TryParse(splitted[3], out int ngramCount);
+            if (!success)
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Expected \"ngram <x> = <y>\" with <x> and <y> being positive integers, but got {currentLine}");
+            }
+            if (counts.ContainsKey(ngramSize))
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Multiple count entries for ngram size {ngramSize}");
+            }
+            counts.Add(ngramSize, ngramCount);
+        }
+
+        // Empty line after header
+        currentLine = inputStream.ReadLine();
+        if (!"".Equals(currentLine))
+        {
+            throw new InvalidDataException($"Invalid ARPA data: Expected empty line, but got \"{currentLine}\"");
+        }
+
+        counts.OrderBy(x => x.Key);
+        var lm = new NGramLanguageModel();
+
+        // NGram probabilities
+        for (int size = 1; size <= counts.Count; size++)
+        {
+            // NGram probabilities - header saying size of following ngrams
+            currentLine = inputStream.ReadLine();
+            if ($"\\{size}-grams:".Equals(currentLine))
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Expected \"{size}-grams:\", but got \"{currentLine}\"");
+            }
+
+            // NGram probabilities - the real values
+            for (int count = 0; count < counts[size]; count++)
+            {
+                currentLine = inputStream.ReadLine();
+                if (currentLine is null || currentLine.Equals(""))
+                {
+                    throw new InvalidDataException($"Invalid ARPA data: Expected \"ngram <x> = <y>\", but got NULL");
+                }
+                string[] splitted = currentLine.Split(' ');
+                if (splitted.Length != size + 1)
+                {
+                    throw new InvalidDataException($"Invalid ARPA data: Expected \"<probability> <ngram>\", but got {currentLine} - wrong ngram format");
+                }
+                if (!Double.TryParse(splitted[0], out double p))
+                {
+                    throw new InvalidDataException($"Invalid ARPA data: Expected \"<probability> <ngram>\" with probability being a double, but got {currentLine}");
+                }
+                string next = splitted.Last();
+                string context = String.Join(' ', splitted.Take(new Range(new Index(1), new Index(1, true))));
+
+                lm.AddNGram((uint)size, context, next, p);
+            }
+
+            // NGram probabilities - blank line after all ngrams of one size
+            currentLine = inputStream.ReadLine();
+            if (!"".Equals(currentLine))
+            {
+                throw new InvalidDataException($"Invalid ARPA data: Expected empty line, but got \"{currentLine}\"");
+            }
+        }
+
+        // Footer
+        currentLine = inputStream.ReadLine();
+        if ("\\end\\".Equals(currentLine))
+        {
+            throw new InvalidDataException($"Invalid ARPA data: Expected \"\\end\\\", but got \"{currentLine}\"");
+        }
+
+        return lm;
+    }
+
+    public static NGramLanguageModel LoadFrom(string filePath) => LoadFrom(File.OpenText(filePath));
+
+    public double GetPerplexity(string sentence)
+    {
+        List<string> tokens = sentence.Split(' ').ToList();
+        tokens.Insert(0, "<s>");
+        tokens.Add("</s>");
+        double perplexity = 1;
+
+        for (int index = 0; index < tokens.Count; index++)
+        {
+            // get probability of ngram
+            double p = 0.5;
+
+            // multiply
+            perplexity *= p;
+        }
+
+        return perplexity;
+    }
 }

--- a/LanguageModel/NGramLanguageModel.cs
+++ b/LanguageModel/NGramLanguageModel.cs
@@ -46,12 +46,13 @@ public class NGramLanguageModel
     {
         // First line of header
         string? currentLine = inputStream.ReadLine();
-        if (!"\\data\\".Equals(currentLine))
+        string expected = "\\data\\";
+        if (!expected.Equals(currentLine))
         {
-            throw new InvalidDataException($"Invalid ARPA data: Expected \"\\data\\\", but got {currentLine}");
+            throw new InvalidDataException($"Invalid ARPA data: Expected \"{expected}\", but got {currentLine}");
         }
 
-        // Remaining part of header
+        // Remaining part of header, including empty line separating it from ngram data
         var counts = new Dictionary<int, int>();
         while((currentLine = inputStream.ReadLine()) != "")
         {
@@ -80,13 +81,6 @@ public class NGramLanguageModel
             counts.Add(ngramSize, ngramCount);
         }
 
-        // Empty line after header
-        currentLine = inputStream.ReadLine();
-        if (!"".Equals(currentLine))
-        {
-            throw new InvalidDataException($"Invalid ARPA data: Expected empty line, but got \"{currentLine}\"");
-        }
-
         counts.OrderBy(x => x.Key);
         var lm = new NGramLanguageModel();
 
@@ -95,9 +89,10 @@ public class NGramLanguageModel
         {
             // NGram probabilities - header saying size of following ngrams
             currentLine = inputStream.ReadLine();
-            if ($"\\{size}-grams:".Equals(currentLine))
+            expected = $"\\{size}-grams:";
+            if (!expected.Equals(currentLine))
             {
-                throw new InvalidDataException($"Invalid ARPA data: Expected \"{size}-grams:\", but got \"{currentLine}\"");
+                throw new InvalidDataException($"Invalid ARPA data: Expected \"{expected}\", but got \"{currentLine}\"");
             }
 
             // NGram probabilities - the real values
@@ -125,7 +120,8 @@ public class NGramLanguageModel
 
             // NGram probabilities - blank line after all ngrams of one size
             currentLine = inputStream.ReadLine();
-            if (!"".Equals(currentLine))
+            expected = "";
+            if (!expected.Equals(currentLine))
             {
                 throw new InvalidDataException($"Invalid ARPA data: Expected empty line, but got \"{currentLine}\"");
             }
@@ -133,9 +129,10 @@ public class NGramLanguageModel
 
         // Footer
         currentLine = inputStream.ReadLine();
-        if ("\\end\\".Equals(currentLine))
+        expected = "\\end\\";
+        if (!expected.Equals(currentLine))
         {
-            throw new InvalidDataException($"Invalid ARPA data: Expected \"\\end\\\", but got \"{currentLine}\"");
+            throw new InvalidDataException($"Invalid ARPA data: Expected \"{expected}\", but got \"{currentLine}\"");
         }
 
         return lm;

--- a/Learn/LearnOptions.cs
+++ b/Learn/LearnOptions.cs
@@ -5,7 +5,7 @@ namespace Learn;
 public class LearnOptions
 {
     [Option('i', "inputFilePath", Required = true, HelpText = "Path to file with input text to learn.")]
-    public string InputFilePath { get; set; }
+    public string InputFilePath { get; set; } = "";
 
     [Option('s', "smoothing", Required = true, HelpText = "Type of smoothing to apply. Supported values: \"Regular\" and \"KneserNey\"")]
     public SmoothingType Smoothing { get; set; }

--- a/Perplexity/Perplexity.csproj
+++ b/Perplexity/Perplexity.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LanguageModel\LanguageModel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Perplexity/PerplexityCalcOptions.cs
+++ b/Perplexity/PerplexityCalcOptions.cs
@@ -1,0 +1,15 @@
+﻿using CommandLine;
+
+namespace Perplexity;
+
+public class PerplexityCalcOptions
+{
+    [Option('m', "model", Required = true, HelpText = "Path to a file containing the language model to use for perplexity calculation. Must be in ARPA format.")]
+    public string LmArpaInputFilePath { get; set; } = "";
+
+    [Option('i', "text", Required = true, HelpText = "The text to calculate the perplexity of.")]
+    public string InputText { get; set; } = "";
+
+    [Option('v', "verbose", Required = false, HelpText = "Enable verbose logging.")]
+    public bool Verbose { get; set; }
+}

--- a/Perplexity/Program.cs
+++ b/Perplexity/Program.cs
@@ -1,0 +1,33 @@
+﻿using CommandLine;
+using LanguageModel;
+using Microsoft.Extensions.Logging;
+
+namespace Perplexity;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Parser.Default.ParseArguments<PerplexityCalcOptions>(args).WithParsed(CalcPerplexity);
+    }
+
+    private static void CalcPerplexity(PerplexityCalcOptions options)
+    {
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            LogLevel logLevel = options.Verbose ? LogLevel.Trace : LogLevel.Information;
+            builder.SetMinimumLevel(logLevel);
+            builder.AddSimpleConsole();
+        });
+
+        Console.WriteLine("Loading LM from file...");
+        NGramLanguageModel lm = NGramLanguageModel.LoadFrom(options.LmArpaInputFilePath);
+        Console.WriteLine("Computing perplexity...");
+        double perplexity = lm.GetPerplexity(options.InputText);
+        Console.WriteLine();
+
+        Console.WriteLine($"Text: \"{options.InputText}\"");
+        Console.WriteLine($"Path to LanguageModel: \"{options.LmArpaInputFilePath}\"");
+        Console.WriteLine($"Perplexity: {perplexity}");
+    }
+}


### PR DESCRIPTION
Add a program, that calculates the perplexity of an input sentence based on a specified language model.

The sentence to calculate the perplexity of and the language model that should be used for the calculation can be freely specified and passed to the program using command line parameters. The only restriction thereby is that the language model must be a file, that contains the language model data in ARPA format.

An integrated command line help is also available.